### PR TITLE
Report API down instead of throwing error.

### DIFF
--- a/lib/catc.js
+++ b/lib/catc.js
@@ -34,10 +34,16 @@ CatC.prototype.execute = function(route, params, cb) {
     json: true,
     method: params.method || 'GET'
   }, function(err, res, body) {
+    var status = body && body.status;
+
     if(!err && res.statusCode === 200) {
       cb(null, body);
     } else {
-      cb({ status: body.status }, null);
+      if (err.code === 'ENETUNREACH') {
+        status = 'down';
+      }
+
+      cb({ status: status }, null);
     }
   });
 };


### PR DESCRIPTION
Previously, when the CatC API server went down, the unchecked err value
would lead to an uncaught exception.

This resolves #3.
